### PR TITLE
updates all funcs to return error instead of panic inline.  NOTE: Bre…

### DIFF
--- a/gopio.go
+++ b/gopio.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"errors"
 )
 
 type Pin struct {
@@ -12,135 +13,136 @@ type Pin struct {
 
 const gpioPath = "/sys/class/gpio/"
 
-func NewPin(id int) *Pin {
+func NewPin(id int) (error, *Pin) {
 	pin := new(Pin)
 	pin.id = strconv.Itoa(id)
 
-	pin.Init()
-	return pin
+	err := pin.Init()
+	return err, pin
 }
 
-func (pin *Pin) Init() {
+func (pin *Pin) Init() error {
 	var err error
 
 	if _, err = os.Stat(gpioPath + "gpio" + pin.id); os.IsNotExist(err) {
 		var file *os.File
 
 		if file, err = os.OpenFile(gpioPath+"export", os.O_APPEND|os.O_WRONLY, 0777); err != nil {
-			panic(err)
+			return err
 		}
 		defer file.Close()
 
 		if _, err = file.WriteString(pin.id); err != nil {
-			panic(err)
+			return err
 		}
 	}
-	return
+	return nil
 }
 
-func (pin *Pin) Close() {
+func (pin *Pin) Close() error {
 	var err error
 	var file *os.File
 
 	if file, err = os.OpenFile(gpioPath+"unexport", os.O_APPEND|os.O_WRONLY, 0777); err != nil {
-		panic(err)
+		return err
 	}
 	defer file.Close()
 
 	if _, err = file.WriteString(pin.id); err != nil {
-		panic(err)
+		return err
 	}
-	return
+	return nil
 }
 
-func (pin *Pin) SetMode(mode string) {
+func (pin *Pin) SetMode(mode string) error {
 	if mode != "in" && mode != "out" {
-		panic("Invalid mode.")
+		return errors.New("Invalid mode.")
 	}
 
 	var err error
 	if _, err = os.Stat(gpioPath + "gpio" + pin.id); err != nil {
-		panic(err)
+		return err
 	}
 
 	var file *os.File
 	if file, err = os.OpenFile(gpioPath+"gpio"+pin.id+"/direction", os.O_APPEND|os.O_WRONLY, 0777); err != nil {
-		panic(err)
+		return err
 	}
 	defer file.Close()
 
 	if _, err = file.WriteString(mode); err != nil {
-		panic(err)
+		return err
 	}
 
-	return
+	return nil
 }
 
-func (pin *Pin) GetMode() string {
+func (pin *Pin) GetMode() (error, string) {
 	var err error
 	if _, err = os.Stat(gpioPath + "gpio" + pin.id); err != nil {
-		panic(err)
+		return err, ""
 	}
 
 	var file *os.File
 	if file, err = os.OpenFile(gpioPath+"gpio"+pin.id+"/direction", os.O_RDONLY, 0777); err != nil {
-		panic(err)
+		return err, ""
 	}
 	defer file.Close()
 
 	var count int
 	data := make([]byte, 3)
 	if count, err = file.Read(data); err != nil {
-		panic(err)
+		return err, ""
 	}
 
-	return strings.TrimSpace(string(data[:count]))
+	return nil, strings.TrimSpace(string(data[:count]))
 }
 
-func (pin *Pin) SetValue(value int) {
+func (pin *Pin) SetValue(value int) error {
 	if value != 1 && value != 0 {
-		panic("Invalid value.")
+		return errors.New("Invalid value.")
 	}
 
 	var err error
 	if _, err = os.Stat(gpioPath + "gpio" + pin.id); err != nil {
-		panic(err)
+		return err
 	}
 
 	var file *os.File
 	if file, err = os.OpenFile(gpioPath+"gpio"+pin.id+"/value", os.O_APPEND|os.O_WRONLY, 0777); err != nil {
-		panic(err)
+		return err
 	}
 	defer file.Close()
 
 	if _, err = file.WriteString(strconv.Itoa(value)); err != nil {
-		panic(err)
+		return err
 	}
 
-	return
+	return nil
 }
 
-func (pin *Pin) GetValue() int {
+func (pin *Pin) GetValue() (error, int) {
 	var err error
+	
 	if _, err = os.Stat(gpioPath + "gpio" + pin.id); err != nil {
-		panic(err)
+		return err, -1
 	}
 
 	var file *os.File
 	if file, err = os.OpenFile(gpioPath+"gpio"+pin.id+"/value", os.O_RDONLY, 0777); err != nil {
-		panic(err)
+		return err, -1
 	}
 	defer file.Close()
 
 	data := make([]byte, 1)
 	if _, err = file.Read(data); err != nil {
-		panic(err)
+		return err, -1
 	}
 
 	var res int
 	if res, err = strconv.Atoi(strings.TrimSpace(string(data))); err != nil {
-		panic(err)
+		return err, -1
 	}
 
-	return res
+	return nil, res
 }


### PR DESCRIPTION
**NOTE: This will break backwards compatibility**

This changes all function calls to return an error instead of panic inline.

This will return empty string "" when error is generated or -1 when error is generated when there is a function that returns a string or int.

The functions will return nil for errors when there are none.

The rational for this request is to allow a more robust way to handle errors if this code is being run on non-gpio enabled systems.
